### PR TITLE
chore: Update Cargo.toml add repository

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ license = "Sovereign Permissionless Commercial License"
 authors = ["Sovereign Labs <info@sovereign.xyz>"]
 publish = false
 rust-version = "1.88"
+repository = "https://github.com/citizen-stig/rollup-starter/"
 
 [workspace.dependencies]
 sov-address = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "349bdcd8b76067b6f120db06a66d518fd8f80f8a", features = [

--- a/crates/rollup/Cargo.toml
+++ b/crates/rollup/Cargo.toml
@@ -4,6 +4,7 @@ version = { workspace = true }
 edition = { workspace = true }
 authors = { workspace = true }
 license = { workspace = true }
+repository = { workspace = true }
 homepage = "sovereign.xyz"
 publish = false
 default-run = "rollup"


### PR DESCRIPTION
According to the [manifest](https://doc.rust-lang.org/cargo/reference/manifest.html) it seems the `repository` field is nice to have.  More explanation https://github.com/szabgab/rust-digger/issues/104